### PR TITLE
use tmpnam instead of tmpnam_s for test routine on unix

### DIFF
--- a/TrackerValidation/test/MeasuredData.test.cpp
+++ b/TrackerValidation/test/MeasuredData.test.cpp
@@ -10,9 +10,9 @@ TEST_CASE("MeasuredData factory", "[MeasuredData]")
     {
         MeasuredData *data = MeasuredData::create("cout", "label", "tracker", "subject", "path");
 
-        REQUIRE(data->getLabel() == "label");
-        REQUIRE(data->getTrackerName() == "tracker");
-        REQUIRE(data->getSubject() == "subject");
+        CHECK(data->getLabel() == "label");
+        CHECK(data->getTrackerName() == "tracker");
+        CHECK(data->getSubject() == "subject");
 
         delete data;
     }
@@ -30,8 +30,12 @@ TEST_CASE("MeasuredData factory", "[MeasuredData]")
 
     SECTION("Create MeasuredDataFile")
     {
-        char tmpFile[64];
+        char tmpFile[L_tmpnam];
+        #ifndef _WIN32
+        REQUIRE(tmpnam(tmpFile) == tmpFile); // returns pointer to tmpFile on success
+        #else
         REQUIRE(tmpnam_s(tmpFile, sizeof(tmpFile)) == 0);
+        #endif
 
         MeasuredData* data = MeasuredData::create("file", "label", "tracker", "subject", tmpFile);
 

--- a/TrackerValidation/test/ScreenPositionStore.test.cpp
+++ b/TrackerValidation/test/ScreenPositionStore.test.cpp
@@ -11,36 +11,36 @@ TEST_CASE("ScreenPositionStore", "[ScreenPositionStore]")
 
     SECTION("Default constructor values")
     {
-        REQUIRE(store.getIdentifier() == 0.0);
-        REQUIRE(store.getCurrentPosition() == std::pair<unsigned int, unsigned int>());
+        CHECK(store.getIdentifier() == 0.0);
+        CHECK(store.getCurrentPosition() == std::pair<unsigned int, unsigned int>());
     }
 
     // test getCurrentPosition and getIdentifier while we're here
     SECTION("setCurrentPosition")
     {
         store.setCurrentPosition(std::make_pair(100, 200), -1.0);
-        REQUIRE(store.getIdentifier() == -1.0);
-        REQUIRE(store.getCurrentPosition() == std::pair<unsigned int, unsigned int>(100, 200));
+        CHECK(store.getIdentifier() == -1.0);
+        CHECK(store.getCurrentPosition() == std::pair<unsigned int, unsigned int>(100, 200));
 
         store.setCurrentPosition(std::make_pair(2, 1), 1.0);
-        REQUIRE(store.getIdentifier() == 1.0);
-        REQUIRE(store.getCurrentPosition() == std::pair<unsigned int, unsigned int>(2, 1));
+        CHECK(store.getIdentifier() == 1.0);
+        CHECK(store.getCurrentPosition() == std::pair<unsigned int, unsigned int>(2, 1));
 
         store.setCurrentPosition(std::make_pair(99, 99), 0.0);
-        REQUIRE(store.getIdentifier() == 0.0);
-        REQUIRE(store.getCurrentPosition() == std::pair<unsigned int, unsigned int>(99, 99));
+        CHECK(store.getIdentifier() == 0.0);
+        CHECK(store.getCurrentPosition() == std::pair<unsigned int, unsigned int>(99, 99));
 
         // we only take positive values. If we feed in a negative value, it's going to wrap
         store.setCurrentPosition(std::make_pair(-1, -2), 0.0);
-        REQUIRE(store.getIdentifier() == 0.0);
-        REQUIRE(store.getCurrentPosition() == std::pair<unsigned int, unsigned int>(0xffffffff, 0xffffffff - 1));
+        CHECK(store.getIdentifier() == 0.0);
+        CHECK(store.getCurrentPosition() == std::pair<unsigned int, unsigned int>(0xffffffff, 0xffffffff - 1));
     }
 
     // edge case - default value fot setCurrentPosition
     SECTION("getIdentifier")
     {
         store.setCurrentPosition(std::make_pair(100, 200));
-        REQUIRE(store.getIdentifier() == 0.0);
-        REQUIRE(store.getCurrentPosition() == std::pair<unsigned int, unsigned int>(100, 200));
+        CHECK(store.getIdentifier() == 0.0);
+        CHECK(store.getCurrentPosition() == std::pair<unsigned int, unsigned int>(100, 200));
     }
 }


### PR DESCRIPTION
Yes there is a hypothetical security issue with tmpnam but we are testing a routine which takes a file path to open, so there is no nice way around this.